### PR TITLE
fix trivial but serious bug in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ if test x${with_mpi} != xno; then
     CXXFLAGS="${CXXFLAGS}"
 fi
 AX_CXX_COMPILE_STDCXX_11([noext])
-CPPFLAGS="-std=c++11 ${CPPFLAGS}"
+CXXFLAGS="-std=c++11 ${CPPFLAGS}"
 
 LT_INIT([disable-static])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,6 @@ if test x${with_mpi} != xno; then
     CXXFLAGS="${CXXFLAGS}"
 fi
 AX_CXX_COMPILE_STDCXX_11([noext])
-CXXFLAGS="-std=c++11 ${CPPFLAGS}"
 
 LT_INIT([disable-static])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
CPPFLAGS is for C preprocessing, not C++ compilation.  setting
-std=c++11 here causes this flag to be used with the C compiler.

more importantly, it causes CPP=/lib/cpp to be inferred, at least on
Mac, and this does not work at all.